### PR TITLE
Rename lynx4ai to lynx-mcp + fix all review findings

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,11 +1,11 @@
 {
   "mcpServers": {
-    "lynx4ai": {
-      "command": "./target/release/lynx4ai",
+    "lynx-mcp": {
+      "command": "./target/release/lynx-mcp",
       "args": [],
       "env": {
         "LYNX_HEADLESS": "true",
-        "RUST_LOG": "lynx4ai=info"
+        "RUST_LOG": "lynx_mcp=info"
       }
     }
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md — lynx4ai
+# AGENTS.md — lynx-mcp
 
 ## Overview
 Rust MCP server for Chrome browser automation via CDP (Chrome DevTools Protocol).
@@ -7,7 +7,7 @@ Reads the web through the accessibility tree instead of pixels — optimized for
 ## Build & Run
 ```bash
 cargo build --release
-# Binary at ./target/release/lynx4ai
+# Binary at ./target/release/lynx-mcp
 # Communicates via stdio (MCP JSON-RPC protocol)
 ```
 
@@ -37,10 +37,10 @@ cargo clippy -- -D warnings   # Lint
 |-----|---------|---------|
 | `LYNX_HEADLESS` | `true` | Headless or headed Chrome |
 | `LYNX_CHROME_PATH` | auto-detect | Chrome binary path |
-| `LYNX_PROFILE_DIR` | `~/.lynx4ai/profiles` | Persistent session storage |
+| `LYNX_PROFILE_DIR` | `~/.lynx-mcp/profiles` | Persistent session storage |
 | `LYNX_EVAL_ENABLED` | `true` | Enable/disable JS eval tool |
 | `LYNX_AUTH_PROVIDER` | `op` | Password manager CLI |
-| `RUST_LOG` | `lynx4ai=info` | Tracing filter |
+| `RUST_LOG` | `lynx_mcp=info` | Tracing filter |
 
 ## MCP Tools (16 total)
 - **Instance**: `instance_create`, `instance_list`, `instance_destroy`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,7 +862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lynx4ai"
+name = "lynx-mcp"
 version = "0.1.0"
 dependencies = [
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
-name = "lynx4ai"
+name = "lynx-mcp"
 version = "0.1.0"
 edition = "2021"
 authors = ["Sean Gray <sean@rhmc.io>"]
 license = "MIT"
 description = "Rust MCP server for AI browser automation via Chrome DevTools Protocol"
-repository = "https://github.com/SeansGravy/lynx4ai"
+repository = "https://github.com/SeansGravy/lynx-mcp"
 keywords = ["mcp", "browser", "automation", "ai", "cdp"]
 categories = ["development-tools", "web-programming"]
 
 [[bin]]
-name = "lynx4ai"
+name = "lynx-mcp"
 path = "src/main.rs"
 
 [lib]
-name = "lynx4ai"
+name = "lynx_mcp"
 path = "src/lib.rs"
 
 [dependencies]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build release install uninstall test test-integration lint check clean
 
 INSTALL_DIR ?= $(HOME)/.local/bin
-BINARY = lynx4ai
+BINARY = lynx-mcp
 
 build:
 	cargo build
@@ -15,7 +15,7 @@ install: release
 	chmod +x $(INSTALL_DIR)/$(BINARY)
 	@echo "Installed: $(INSTALL_DIR)/$(BINARY)"
 	@echo ""
-	@echo "Add to Claude Code:  claude mcp add lynx4ai $(INSTALL_DIR)/$(BINARY)"
+	@echo "Add to Claude Code:  claude mcp add lynx-mcp $(INSTALL_DIR)/$(BINARY)"
 
 uninstall:
 	rm -f $(INSTALL_DIR)/$(BINARY)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lynx4ai
+# lynx-mcp
 
 Rust MCP server for AI browser automation via Chrome DevTools Protocol.
 
@@ -8,7 +8,7 @@ Reads the web through the accessibility tree instead of pixels — like the orig
 
 In 1992, [Lynx](https://en.wikipedia.org/wiki/Lynx_(web_browser)) proved you could browse the entire web with nothing but text in a terminal. No images, no CSS, no JavaScript rendering — just the content, fast and clean.
 
-lynx4ai carries that same philosophy forward for AI agents. Instead of rendering pixels and taking screenshots, it reads the web the way a screen reader does — through the accessibility tree. The result: structured, semantic page data at ~800 tokens instead of ~4,000 vision tokens for a screenshot.
+lynx-mcp carries that same philosophy forward for AI agents. Instead of rendering pixels and taking screenshots, it reads the web the way a screen reader does — through the accessibility tree. The result: structured, semantic page data at ~800 tokens instead of ~4,000 vision tokens for a screenshot.
 
 Same idea, different era. Text was enough then. Structure is enough now.
 
@@ -17,16 +17,16 @@ Same idea, different era. Text was enough then. Structure is enough now.
 - **Lynx (1992)** — The original text-mode browser. Proved the web is content, not rendering.
 - **Pinchtab (2025)** — Pioneered accessibility-tree snapshots with stable refs for AI agents.
 - **Sean's LLM browser hacks (2025-2026)** — Battle-tested patterns for modal dismissal, response stability detection, and resilient form automation across ChatGPT, Grok, and others.
-- **lynx4ai (2026)** — All of the above, in Rust, as an MCP server. One binary. No runtime deps.
+- **lynx-mcp (2026)** — All of the above, in Rust, as an MCP server. One binary. No runtime deps.
 
 ## Use Cases
 
 ### Cross-LLM Automation
 
-Use one AI to drive another through the browser. lynx4ai gives any MCP-capable agent full browser control — including navigating to other LLM web interfaces.
+Use one AI to drive another through the browser. lynx-mcp gives any MCP-capable agent full browser control — including navigating to other LLM web interfaces.
 
-- **Claude driving ChatGPT** — Use Claude Code with lynx4ai to navigate to chat.openai.com, type prompts, read responses, compare outputs
-- **Codex driving Claude** — Have OpenAI's Codex CLI use lynx4ai to interact with Claude's web UI
+- **Claude driving ChatGPT** — Use Claude Code with lynx-mcp to navigate to chat.openai.com, type prompts, read responses, compare outputs
+- **Codex driving Claude** — Have OpenAI's Codex CLI use lynx-mcp to interact with Claude's web UI
 - **Multi-model comparison** — Write a script that sends the same prompt to ChatGPT, Gemini, and Grok via their web UIs, then collects and compares all responses
 - **Best-of-N routing** — Agent navigates to multiple LLM interfaces, asks each the same question, picks the best answer
 - **LLM-as-judge via browser** — One model evaluates another model's web UI output by reading the accessibility tree
@@ -36,7 +36,7 @@ Use one AI to drive another through the browser. lynx4ai gives any MCP-capable a
 Persistent Chrome profiles mean you log in once and stay logged in. Combine with `auth_login` for fully automated credential entry.
 
 - **Medical portals** — Pull lab results, appointment history, medication lists from MyChart or similar
-- **Corporate intranets** — Navigate internal dashboards, HR systems, IT portals, wiki pages, ticketing systems (ServiceNow, Jira, Confluence) — anything your browser can reach, lynx4ai can read
+- **Corporate intranets** — Navigate internal dashboards, HR systems, IT portals, wiki pages, ticketing systems (ServiceNow, Jira, Confluence) — anything your browser can reach, lynx-mcp can read
 - **Banking & finance** — Check balances, download statements, monitor transactions
 - **Government portals** — Tax filings, benefits status, license renewals
 - **SaaS dashboards** — Pull data from admin panels, analytics dashboards, CRM systems
@@ -85,23 +85,23 @@ Persistent Chrome profiles mean you log in once and stay logged in. Combine with
 ### One-liner (macOS / Linux)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/SeansGravy/lynx4ai/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/SeansGravy/lynx-mcp/main/install.sh | bash
 ```
 
 This will:
 - Detect your platform (macOS Intel/Apple Silicon, Linux x86_64/ARM)
 - Install Chrome if missing (via Homebrew on macOS, apt/dnf/pacman on Linux)
 - Install Rust if needed (via rustup)
-- Build from source and install to `~/.local/bin/lynx4ai`
+- Build from source and install to `~/.local/bin/lynx-mcp`
 - Print setup instructions for your AI tool
 
 ### From source (manual)
 
 ```bash
-git clone https://github.com/SeansGravy/lynx4ai.git
-cd lynx4ai
+git clone https://github.com/SeansGravy/lynx-mcp.git
+cd lynx-mcp
 make install
-# or: cargo build --release && cp target/release/lynx4ai ~/.local/bin/
+# or: cargo build --release && cp target/release/lynx-mcp ~/.local/bin/
 ```
 
 ### Requirements
@@ -112,12 +112,12 @@ make install
 
 ## Setup
 
-lynx4ai works with any AI tool that supports MCP (Model Context Protocol) over stdio. Here's how to set it up for each one.
+lynx-mcp works with any AI tool that supports MCP (Model Context Protocol) over stdio. Here's how to set it up for each one.
 
 ### Claude Code
 
 ```bash
-claude mcp add lynx4ai ~/.local/bin/lynx4ai
+claude mcp add lynx-mcp ~/.local/bin/lynx-mcp
 ```
 
 ### Claude Desktop
@@ -127,8 +127,8 @@ Add to `claude_desktop_config.json`:
 ```json
 {
   "mcpServers": {
-    "lynx4ai": {
-      "command": "~/.local/bin/lynx4ai"
+    "lynx-mcp": {
+      "command": "~/.local/bin/lynx-mcp"
     }
   }
 }
@@ -137,19 +137,19 @@ Add to `claude_desktop_config.json`:
 ### OpenAI Codex CLI
 
 ```bash
-codex mcp add lynx4ai -- ~/.local/bin/lynx4ai
+codex mcp add lynx-mcp -- ~/.local/bin/lynx-mcp
 ```
 
 Or add to `~/.codex/config.toml`:
 
 ```toml
-[mcp_servers.lynx4ai]
-command = "~/.local/bin/lynx4ai"
+[mcp_servers.lynx-mcp]
+command = "~/.local/bin/lynx-mcp"
 ```
 
 ### ChatGPT Desktop
 
-ChatGPT Desktop only supports remote (HTTPS) MCP servers, not local stdio. To use lynx4ai with ChatGPT, you'd need to wrap it in an HTTP bridge like [mcp-proxy](https://github.com/nichochar/mcp-proxy) or [mcp.run](https://www.mcp.run).
+ChatGPT Desktop only supports remote (HTTPS) MCP servers, not local stdio. To use lynx-mcp with ChatGPT, you'd need to wrap it in an HTTP bridge like [mcp-proxy](https://github.com/nichochar/mcp-proxy) or [mcp.run](https://www.mcp.run).
 
 ### Cursor
 
@@ -158,8 +158,8 @@ Add to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project):
 ```json
 {
   "mcpServers": {
-    "lynx4ai": {
-      "command": "~/.local/bin/lynx4ai"
+    "lynx-mcp": {
+      "command": "~/.local/bin/lynx-mcp"
     }
   }
 }
@@ -172,8 +172,8 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 ```json
 {
   "mcpServers": {
-    "lynx4ai": {
-      "command": "~/.local/bin/lynx4ai"
+    "lynx-mcp": {
+      "command": "~/.local/bin/lynx-mcp"
     }
   }
 }
@@ -188,8 +188,8 @@ Add to `.vscode/mcp.json` in your project:
 ```json
 {
   "servers": {
-    "lynx4ai": {
-      "command": "~/.local/bin/lynx4ai"
+    "lynx-mcp": {
+      "command": "~/.local/bin/lynx-mcp"
     }
   }
 }
@@ -200,13 +200,13 @@ Add to `.vscode/mcp.json` in your project:
 Or via command line:
 
 ```bash
-code --add-mcp '{"name":"lynx4ai","command":"~/.local/bin/lynx4ai"}'
+code --add-mcp '{"name":"lynx-mcp","command":"~/.local/bin/lynx-mcp"}'
 ```
 
 ### Gemini CLI
 
 ```bash
-gemini mcp add lynx4ai ~/.local/bin/lynx4ai
+gemini mcp add lynx-mcp ~/.local/bin/lynx-mcp
 ```
 
 Or add to `~/.gemini/settings.json`:
@@ -214,8 +214,8 @@ Or add to `~/.gemini/settings.json`:
 ```json
 {
   "mcpServers": {
-    "lynx4ai": {
-      "command": "~/.local/bin/lynx4ai"
+    "lynx-mcp": {
+      "command": "~/.local/bin/lynx-mcp"
     }
   }
 }
@@ -226,7 +226,7 @@ Or add to `~/.gemini/settings.json`:
 The xAI API supports remote MCP servers only (HTTP/SSE). For local stdio, use the third-party [grok-cli](https://github.com/superagent-ai/grok-cli):
 
 ```bash
-grok mcp add lynx4ai --transport stdio --command ~/.local/bin/lynx4ai
+grok mcp add lynx-mcp --transport stdio --command ~/.local/bin/lynx-mcp
 ```
 
 Or add to `.grok/settings.json`:
@@ -234,9 +234,9 @@ Or add to `.grok/settings.json`:
 ```json
 {
   "mcpServers": {
-    "lynx4ai": {
+    "lynx-mcp": {
       "transport": "stdio",
-      "command": "~/.local/bin/lynx4ai"
+      "command": "~/.local/bin/lynx-mcp"
     }
   }
 }
@@ -245,7 +245,7 @@ Or add to `.grok/settings.json`:
 ### Amazon Q Developer
 
 ```bash
-q mcp add --name lynx4ai --command ~/.local/bin/lynx4ai
+q mcp add --name lynx-mcp --command ~/.local/bin/lynx-mcp
 ```
 
 Or add to `~/.aws/amazonq/mcp.json`:
@@ -253,8 +253,8 @@ Or add to `~/.aws/amazonq/mcp.json`:
 ```json
 {
   "mcpServers": {
-    "lynx4ai": {
-      "command": "~/.local/bin/lynx4ai"
+    "lynx-mcp": {
+      "command": "~/.local/bin/lynx-mcp"
     }
   }
 }
@@ -267,8 +267,8 @@ Open the Cline sidebar in VS Code, click the MCP Servers icon, select "Configure
 ```json
 {
   "mcpServers": {
-    "lynx4ai": {
-      "command": "~/.local/bin/lynx4ai",
+    "lynx-mcp": {
+      "command": "~/.local/bin/lynx-mcp",
       "disabled": false
     }
   }
@@ -279,21 +279,21 @@ Open the Cline sidebar in VS Code, click the MCP Servers icon, select "Configure
 
 | Tool | Config | CLI Shortcut |
 |------|--------|-------------|
-| Claude Code | automatic | `claude mcp add lynx4ai ~/.local/bin/lynx4ai` |
+| Claude Code | automatic | `claude mcp add lynx-mcp ~/.local/bin/lynx-mcp` |
 | Claude Desktop | `claude_desktop_config.json` | — |
-| Codex CLI | `~/.codex/config.toml` | `codex mcp add lynx4ai -- ~/.local/bin/lynx4ai` |
+| Codex CLI | `~/.codex/config.toml` | `codex mcp add lynx-mcp -- ~/.local/bin/lynx-mcp` |
 | ChatGPT Desktop | HTTP only (needs bridge) | — |
 | Cursor | `~/.cursor/mcp.json` | — |
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` | — |
 | VS Code Copilot | `.vscode/mcp.json` | `code --add-mcp '{...}'` |
-| Gemini CLI | `~/.gemini/settings.json` | `gemini mcp add lynx4ai ~/.local/bin/lynx4ai` |
-| Grok (grok-cli) | `.grok/settings.json` | `grok mcp add lynx4ai --transport stdio ...` |
-| Amazon Q | `~/.aws/amazonq/mcp.json` | `q mcp add --name lynx4ai --command ...` |
+| Gemini CLI | `~/.gemini/settings.json` | `gemini mcp add lynx-mcp ~/.local/bin/lynx-mcp` |
+| Grok (grok-cli) | `.grok/settings.json` | `grok mcp add lynx-mcp --transport stdio ...` |
+| Amazon Q | `~/.aws/amazonq/mcp.json` | `q mcp add --name lynx-mcp --command ...` |
 | Cline | VS Code globalStorage | — |
 
 ## Usage
 
-Once lynx4ai is set up as an MCP server, just talk to your AI in plain English. The AI figures out which tools to call. Here are some things you can say:
+Once lynx-mcp is set up as an MCP server, just talk to your AI in plain English. The AI figures out which tools to call. Here are some things you can say:
 
 ### Basic browsing
 
@@ -419,10 +419,10 @@ You can also be explicit about which tools to use:
 |----------|---------|-------------|
 | `LYNX_HEADLESS` | `true` | Run Chrome in headless mode |
 | `LYNX_CHROME_PATH` | auto-detect | Path to Chrome binary |
-| `LYNX_PROFILE_DIR` | `~/.lynx4ai/profiles` | Persistent session storage |
+| `LYNX_PROFILE_DIR` | `~/.lynx-mcp/profiles` | Persistent session storage |
 | `LYNX_EVAL_ENABLED` | `true` | Enable/disable JavaScript eval tool |
 | `LYNX_AUTH_PROVIDER` | `op` | Password manager CLI (1Password) |
-| `RUST_LOG` | `lynx4ai=info` | Tracing filter |
+| `RUST_LOG` | `lynx_mcp=info` | Tracing filter |
 
 ## How It Works
 
@@ -457,7 +457,7 @@ cargo clippy
 
 # Release (optimized single binary)
 cargo build --release
-# Binary at ./target/release/lynx4ai
+# Binary at ./target/release/lynx-mcp
 ```
 
 ## License

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# lynx4ai installer for macOS / Linux
-# Usage: curl -fsSL https://raw.githubusercontent.com/SeansGravy/lynx4ai/main/install.sh | bash
+# lynx-mcp installer for macOS / Linux
+# Usage: curl -fsSL https://raw.githubusercontent.com/SeansGravy/lynx-mcp/main/install.sh | bash
 set -euo pipefail
 
-REPO="SeansGravy/lynx4ai"
-BINARY="lynx4ai"
+REPO="SeansGravy/lynx-mcp"
+BINARY="lynx-mcp"
 INSTALL_DIR="${LYNX_INSTALL_DIR:-$HOME/.local/bin}"
 
 # --- Colors ---
@@ -16,10 +16,10 @@ DIM='\033[2m'
 BOLD='\033[1m'
 NC='\033[0m'
 
-info()  { echo -e "${CYAN}[lynx4ai]${NC} $*"; }
-ok()    { echo -e "${GREEN}[lynx4ai]${NC} $*"; }
-warn()  { echo -e "${YELLOW}[lynx4ai]${NC} $*"; }
-fail()  { echo -e "${RED}[lynx4ai]${NC} $*"; exit 1; }
+info()  { echo -e "${CYAN}[lynx-mcp]${NC} $*"; }
+ok()    { echo -e "${GREEN}[lynx-mcp]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[lynx-mcp]${NC} $*"; }
+fail()  { echo -e "${RED}[lynx-mcp]${NC} $*"; exit 1; }
 
 # --- Banner ---
 echo ""
@@ -160,7 +160,7 @@ else
         ok "Chrome installed: $CHROME_VERSION"
     else
         warn "Chrome not detected after install attempt."
-        warn "lynx4ai requires Chrome or Chromium at runtime."
+        warn "lynx-mcp requires Chrome or Chromium at runtime."
     fi
 fi
 
@@ -168,7 +168,7 @@ fi
 # (only needed if building from source — checked below)
 
 # ============================================================
-# Install lynx4ai
+# Install lynx-mcp
 # ============================================================
 
 # Try to find a pre-built release first
@@ -217,10 +217,10 @@ if [ "$BUILD_FROM_SOURCE" = true ]; then
     trap 'rm -rf "$TMPDIR"' EXIT
 
     info "Cloning $REPO..."
-    git clone --depth 1 "https://github.com/$REPO.git" "$TMPDIR/lynx4ai" 2>/dev/null
+    git clone --depth 1 "https://github.com/$REPO.git" "$TMPDIR/lynx-mcp" 2>/dev/null
 
     info "Building release binary (this may take a minute)..."
-    cd "$TMPDIR/lynx4ai"
+    cd "$TMPDIR/lynx-mcp"
     cargo build --release 2>&1 | tail -1
 
     cp "target/release/$BINARY" "$INSTALL_DIR/$BINARY"
@@ -272,15 +272,15 @@ echo -e "${BOLD}Setup for your AI tool:${NC}"
 echo ""
 echo -e "  ${CYAN}Claude Code${NC} — run this command:"
 echo ""
-echo -e "    claude mcp add lynx4ai $INSTALLED_PATH"
+echo -e "    claude mcp add lynx-mcp $INSTALLED_PATH"
 echo ""
 echo -e "  ${CYAN}Claude Desktop${NC} — add to claude_desktop_config.json:"
 echo ""
-echo -e '    "lynx4ai": { "command": "'$INSTALLED_PATH'" }'
+echo -e '    "lynx-mcp": { "command": "'$INSTALLED_PATH'" }'
 echo ""
 echo -e "  ${CYAN}Cursor / Windsurf / Codex${NC} — add to .mcp.json:"
 echo ""
-echo -e '    { "mcpServers": { "lynx4ai": { "command": "'$INSTALLED_PATH'" } } }'
+echo -e '    { "mcpServers": { "lynx-mcp": { "command": "'$INSTALLED_PATH'" } } }'
 echo ""
 
 # --- Optional deps ---
@@ -299,7 +299,7 @@ fi
 
 # --- Summary ---
 echo -e "${BOLD}Installed:${NC}"
-echo -e "  ${GREEN}lynx4ai${NC}  $INSTALLED_PATH ($SIZE)"
+echo -e "  ${GREEN}lynx-mcp${NC}  $INSTALLED_PATH ($SIZE)"
 [ "$CHROME_FOUND" = true ] && echo -e "  ${GREEN}chrome${NC}   $CHROME_VERSION"
 echo -e "  ${GREEN}git${NC}      $(git --version 2>/dev/null)"
 command -v cargo &>/dev/null && echo -e "  ${GREEN}rust${NC}     $(rustc --version 2>/dev/null)"

--- a/review_summary.md
+++ b/review_summary.md
@@ -1,0 +1,32 @@
+### Code Review Summary
+
+The `lynx-mcp` project is a well-structured Rust application designed for browser automation via the Chrome DevTools Protocol (CDP).
+
+**Strengths:**
+*   **Modular Design**: Clear separation of concerns into modules (`browser`, `snapshot`, `auth`, `error`, `server`, `types`).
+*   **Robust Browser Management**: The `BrowserManager` handles instance creation, destruction, and robust auto-recovery from crashed browser processes. It also smartly cleans up stale Chrome lock files.
+*   **Intelligent Snapshotting**: The `snapshot` module uses JavaScript injection to build an accessibility tree, assigning stable `data-lynx-ref` IDs, which are crucial for reliable element interaction. It offers both detailed JSON and compact, token-efficient output.
+*   **Reliable Element Interaction**: `click`, `type_text`, and `press` implementations are sophisticated, using trusted browser events and multiple strategies to ensure compatibility with various web frameworks.
+*   **Comprehensive Error Handling**: Uses `thiserror` to define a detailed `LynxError` enum, providing good context for debugging.
+*   **Extensible Auth**: The `CredentialProvider` trait provides a good base for future authentication methods.
+*   **Good Use of `chromiumoxide`**: Effectively leverages the `chromiumoxide` library for CDP interactions.
+
+**Areas for Improvement/Further Development:**
+*   **Outdated `AGENTS.md`**: The documentation about ignored integration tests is incorrect.
+*   **Incomplete `auth_login`**: The `auth_login` command currently fetches credentials and navigates but lacks the iterative form-filling logic.
+*   **Unimplemented `upload_file`**: The `upload_file` command is a placeholder.
+*   **Unused Parameters**: `_block_images` in `navigate` and `_selector` in `snapshot` are unused and should be removed or implemented.
+*   **Redundant `BackendNodeId` in `RefMap`**: The `BackendNodeId` in `RefMap` is not currently used for element interaction and could be removed for simplification.
+*   **Dead Code**: Some `#[allow(dead_code)]` attributes and unused variables should be addressed.
+*   **`wait_for_stable`**: Could be improved with more dynamic waiting strategies beyond fixed sleep and `innerText` polling.
+*   **`CredentialProvider` Trait Implementation**: The `op_cli` module does not explicitly implement the `CredentialProvider` trait.
+
+### Functional Testing Summary
+
+Initial attempts at functional testing by directly running the `lynx-mcp` binary via shell scripts were unsuccessful because the `lynx-mcp` server is designed as a long-running process that communicates continuously over stdio (JSON-RPC), not as a command-line tool executed for each individual request.
+
+Despite the `AGENTS.md` file indicating the presence of ignored integration tests that "needs Chrome" (run with `cargo test -- --ignored`), a thorough search of the codebase and execution of the specified test command revealed that **no such integration tests currently exist** in the repository.
+
+Therefore, to perform comprehensive functional testing, new integration tests or a dedicated test harness capable of establishing and maintaining a persistent stdio connection with the `lynx-mcp` server would need to be developed. This falls outside the immediate scope of a code review.
+
+I have completed the requested code review and the investigation into functional testing. Please let me know if you have any further questions or tasks.

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Define the path to the lynx-mcp binary
+LYNX_BIN="./target/release/lynx-mcp"
+GEMINI_TEMP_DIR="/Users/seansgravy/.gemini/tmp/0ad70affc30bbc3172cc569b2be4c4f595f60d73cd1f53d31bac350302e5a7d4"
+STDERR_LOG="$GEMINI_TEMP_DIR/lynx-mcp_stderr.log"
+
+# --- Test 1: instance_create ---
+echo "--- Running instance_create ---"
+INSTANCE_CREATE_REQ='{"jsonrpc": "2.0", "id": 1, "method": "instance_create", "params": {"profile": "test_profile", "headless": true}}'
+
+echo "Sending request:"
+echo "$INSTANCE_CREATE_REQ" | jq . # Pretty print the request
+
+# Create a unique named pipe for stdout
+FIFO_OUT="/tmp/lynx-mcp_fifo_out_$$"
+mkfifo "$FIFO_OUT"
+
+# Redirect lynx-mcp's stderr to a log file and its stdout to the named pipe
+# Run in background to let the main script continue
+# IMPORTANT: The <(...) syntax provides the input to the command.
+# "$LYNX_BIN" is the executable
+# 1>"FIFO_OUT" redirects stdout to our named pipe
+# 2>"STDERR_LOG" redirects stderr to our log file
+"$LYNX_BIN" <(echo "$INSTANCE_CREATE_REQ") 1>"$FIFO_OUT" 2>"$STDERR_LOG" &
+LYNX_PID=$!
+
+# Read from the named pipe, which contains the JSON-RPC response
+INSTANCE_CREATE_RESPONSE=$(cat "$FIFO_OUT")
+
+# Clean up
+rm "$FIFO_OUT"
+
+# Wait for lynx-mcp to exit and kill it just in case
+wait "$LYNX_PID" 2>/dev/null
+kill "$LYNX_PID" 2>/dev/null
+
+echo "Received raw response:"
+echo "$INSTANCE_CREATE_RESPONSE"
+
+echo "Content of $STDERR_LOG:"
+cat "$STDERR_LOG"
+
+# Try to extract instance ID (assuming success and 'result' field)
+INSTANCE_ID=$(echo "$INSTANCE_CREATE_RESPONSE" | jq -r '.result | capture("Instance created: (?<id>[a-f0-9-]+)").id' 2>/dev/null)
+
+if [ -z "$INSTANCE_ID" ]; then
+    echo "ERROR: Failed to extract instance ID from response. Raw response was:"
+    echo "$INSTANCE_CREATE_RESPONSE"
+    echo "And stderr log was:"
+    cat "$STDERR_LOG"
+    exit 1
+fi
+
+echo "Extracted Instance ID: $INSTANCE_ID"
+
+# The rest of the script (navigate, snapshot, destroy) will also need to be run
+# with the same pattern of capturing response and stderr.
+# For debugging the first step, we'll stop here.
+# --- Test 2: navigate ---
+# echo "--- Running navigate ---"
+# ...
+
+# --- Test 3: snapshot ---
+# echo "--- Running snapshot ---"
+# ...
+
+# --- Test 4: instance_destroy ---
+# echo "--- Running instance_destroy ---"
+# ...
+
+# echo "Basic functional tests completed successfully."

--- a/src/auth/form_fill.rs
+++ b/src/auth/form_fill.rs
@@ -1,13 +1,232 @@
-// Iterative login form detection and credential injection
-// Uses snapshot refs to find username/password fields and submit buttons
-// Handles multi-page login flows (e.g., username page → password page → TOTP page)
-//
-// Algorithm:
-// 1. Take snapshot with filter=interactive
-// 2. Find textbox elements with names containing "user", "email", "login"
-// 3. Find textbox elements with names containing "pass"
-// 4. Fill visible fields, click submit button (or press Enter)
-// 5. Re-snapshot — if new fields appear (TOTP, verification), fill those too
-// 6. Repeat up to 5 iterations
-//
-// TODO: implement once click/type_text CDP actions are fully wired
+use crate::auth::Credentials;
+use crate::browser::instance::BrowserInstance;
+use crate::error::LynxError;
+use crate::types::SnapshotNode;
+
+const MAX_LOGIN_ITERATIONS: usize = 5;
+
+/// Patterns to match username-like fields (case-insensitive against name)
+const USERNAME_PATTERNS: &[&str] = &["user", "email", "login", "account", "identifier"];
+/// Patterns to match password-like fields
+const PASSWORD_PATTERNS: &[&str] = &["pass", "secret", "pwd"];
+/// Patterns to match TOTP/MFA fields
+const TOTP_PATTERNS: &[&str] = &[
+    "totp",
+    "otp",
+    "mfa",
+    "verification",
+    "code",
+    "2fa",
+    "authenticator",
+];
+/// Patterns to match submit buttons
+const SUBMIT_PATTERNS: &[&str] = &["sign in", "log in", "login", "submit", "continue", "next"];
+
+/// Find a textbox node whose name matches any of the given patterns
+fn find_field<'a>(nodes: &'a [SnapshotNode], patterns: &[&str]) -> Option<&'a SnapshotNode> {
+    nodes.iter().find(|n| {
+        (n.role == "textbox" || n.role == "searchbox") && n.interactive && {
+            let name_lower = n.name.to_lowercase();
+            patterns.iter().any(|p| name_lower.contains(p))
+        }
+    })
+}
+
+/// Find a submit-like button
+fn find_submit_button(nodes: &[SnapshotNode]) -> Option<&SnapshotNode> {
+    // First try: button with submit-like name
+    if let Some(btn) = nodes.iter().find(|n| {
+        n.role == "button" && {
+            let name_lower = n.name.to_lowercase();
+            SUBMIT_PATTERNS.iter().any(|p| name_lower.contains(p))
+        }
+    }) {
+        return Some(btn);
+    }
+    // Fallback: any interactive button
+    nodes.iter().find(|n| n.role == "button" && n.interactive)
+}
+
+/// Iterative login form fill.
+///
+/// Takes snapshots, finds username/password/TOTP fields by name pattern,
+/// fills them with credentials, clicks submit, and repeats up to 5 times
+/// to handle multi-page login flows (username → password → TOTP).
+pub async fn fill_login_form(
+    instance: &mut BrowserInstance,
+    creds: &Credentials,
+) -> Result<String, LynxError> {
+    let mut status_log = Vec::new();
+
+    for iteration in 0..MAX_LOGIN_ITERATIONS {
+        // Take interactive-only snapshot
+        instance
+            .snapshot(Some("interactive"), false, "compact", None, None)
+            .await?;
+
+        let nodes = match instance.last_snapshot {
+            Some(ref snap) => snap.clone(),
+            None => {
+                status_log.push(format!("iter {iteration}: no snapshot available"));
+                break;
+            }
+        };
+
+        let mut acted = false;
+
+        // Try to find and fill username field
+        if let Some(user_field) = find_field(&nodes, USERNAME_PATTERNS) {
+            instance
+                .type_text(&user_field.ref_id, &creds.username, true)
+                .await?;
+            status_log.push(format!(
+                "iter {iteration}: typed username into {}",
+                user_field.ref_id
+            ));
+            acted = true;
+        }
+
+        // Try to find and fill password field
+        if let Some(pass_field) = find_field(&nodes, PASSWORD_PATTERNS) {
+            instance
+                .type_text(&pass_field.ref_id, &creds.password, true)
+                .await?;
+            status_log.push(format!(
+                "iter {iteration}: typed password into {}",
+                pass_field.ref_id
+            ));
+            acted = true;
+        }
+
+        // Try to find and fill TOTP field
+        if let Some(totp) = &creds.totp
+            && let Some(totp_field) = find_field(&nodes, TOTP_PATTERNS)
+        {
+            instance.type_text(&totp_field.ref_id, totp, true).await?;
+            status_log.push(format!(
+                "iter {iteration}: typed TOTP into {}",
+                totp_field.ref_id
+            ));
+            acted = true;
+        }
+
+        if !acted {
+            status_log.push(format!(
+                "iter {iteration}: no fillable fields found — login may be complete"
+            ));
+            break;
+        }
+
+        // Click submit button or press Enter on last filled field
+        if let Some(submit_btn) = find_submit_button(&nodes) {
+            instance.click(&submit_btn.ref_id).await?;
+            status_log.push(format!(
+                "iter {iteration}: clicked submit {}",
+                submit_btn.ref_id
+            ));
+        } else {
+            // Press Enter on the last field we filled
+            let last_field = find_field(&nodes, PASSWORD_PATTERNS)
+                .or_else(|| find_field(&nodes, TOTP_PATTERNS))
+                .or_else(|| find_field(&nodes, USERNAME_PATTERNS));
+            if let Some(field) = last_field {
+                instance.press(&field.ref_id, "Enter").await?;
+                status_log.push(format!(
+                    "iter {iteration}: pressed Enter on {}",
+                    field.ref_id
+                ));
+            }
+        }
+
+        // Wait for page transition after submit
+        tokio::time::sleep(tokio::time::Duration::from_millis(2000)).await;
+    }
+
+    Ok(status_log.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_textbox(ref_id: &str, name: &str) -> SnapshotNode {
+        SnapshotNode {
+            ref_id: ref_id.to_string(),
+            role: "textbox".to_string(),
+            name: name.to_string(),
+            description: None,
+            value: None,
+            interactive: true,
+            children: Vec::new(),
+        }
+    }
+
+    fn make_button(ref_id: &str, name: &str) -> SnapshotNode {
+        SnapshotNode {
+            ref_id: ref_id.to_string(),
+            role: "button".to_string(),
+            name: name.to_string(),
+            description: None,
+            value: None,
+            interactive: true,
+            children: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn find_username_by_user() {
+        let nodes = vec![
+            make_textbox("e0", "Username"),
+            make_textbox("e1", "Password"),
+        ];
+        let found = find_field(&nodes, USERNAME_PATTERNS);
+        assert_eq!(found.unwrap().ref_id, "e0");
+    }
+
+    #[test]
+    fn find_username_by_email() {
+        let nodes = vec![
+            make_textbox("e0", "Email address"),
+            make_textbox("e1", "Password"),
+        ];
+        let found = find_field(&nodes, USERNAME_PATTERNS);
+        assert_eq!(found.unwrap().ref_id, "e0");
+    }
+
+    #[test]
+    fn find_password_field() {
+        let nodes = vec![
+            make_textbox("e0", "Username"),
+            make_textbox("e1", "Password"),
+        ];
+        let found = find_field(&nodes, PASSWORD_PATTERNS);
+        assert_eq!(found.unwrap().ref_id, "e1");
+    }
+
+    #[test]
+    fn find_totp_field() {
+        let nodes = vec![make_textbox("e0", "Enter verification code")];
+        let found = find_field(&nodes, TOTP_PATTERNS);
+        assert!(found.is_some());
+    }
+
+    #[test]
+    fn find_submit_by_name() {
+        let nodes = vec![make_button("e0", "Cancel"), make_button("e1", "Sign In")];
+        let found = find_submit_button(&nodes);
+        assert_eq!(found.unwrap().ref_id, "e1");
+    }
+
+    #[test]
+    fn find_submit_fallback_to_any_button() {
+        let nodes = vec![make_button("e0", "Go")];
+        let found = find_submit_button(&nodes);
+        assert_eq!(found.unwrap().ref_id, "e0");
+    }
+
+    #[test]
+    fn no_match_returns_none() {
+        let nodes = vec![make_textbox("e0", "Search")];
+        assert!(find_field(&nodes, PASSWORD_PATTERNS).is_none());
+    }
+}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,16 +1,6 @@
 pub mod form_fill;
 pub mod op_cli;
 
-/// Generic credential provider trait
-/// Extensible to support password managers beyond 1Password
-pub trait CredentialProvider {
-    fn get_credentials(
-        &self,
-        item: &str,
-        vault: Option<&str>,
-    ) -> Result<Credentials, crate::error::LynxError>;
-}
-
 /// Credentials returned by a password manager
 #[derive(Debug, Clone)]
 pub struct Credentials {

--- a/src/browser/config.rs
+++ b/src/browser/config.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 pub struct LynxConfig {
     pub chrome_path: PathBuf,
     pub profile_dir: PathBuf,
+    #[allow(dead_code)]
     pub headless: bool,
 }
 
@@ -15,7 +16,7 @@ impl LynxConfig {
                 .unwrap_or_else(|_| detect_chrome()),
             profile_dir: std::env::var("LYNX_PROFILE_DIR")
                 .map(PathBuf::from)
-                .unwrap_or_else(|_| home.join(".lynx4ai").join("profiles")),
+                .unwrap_or_else(|_| home.join(".lynx-mcp").join("profiles")),
             headless: std::env::var("LYNX_HEADLESS")
                 .map(|v| v != "false" && v != "0")
                 .unwrap_or(true),

--- a/src/browser/instance.rs
+++ b/src/browser/instance.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
+use chromiumoxide::Page;
 use chromiumoxide::browser::{Browser, BrowserConfig};
+use chromiumoxide::cdp::browser_protocol::emulation::SetDeviceMetricsOverrideParams;
 use chromiumoxide::cdp::browser_protocol::input::{
     DispatchMouseEventParams, DispatchMouseEventType, MouseButton,
 };
-use chromiumoxide::Page;
 use futures_util::StreamExt;
 use tokio::task::JoinHandle;
 
@@ -53,12 +54,15 @@ impl RefMap {
 pub struct BrowserInstance {
     pub id: InstanceId,
     pub profile: String,
+    #[allow(dead_code)]
     pub browser: Browser,
     pub page: Page,
     pub ref_map: RefMap,
     pub last_snapshot: Option<Vec<crate::types::SnapshotNode>>,
+    pub snapshot_version: u64,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub headless: bool,
+    pub block_images: bool,
     handler: JoinHandle<()>,
 }
 
@@ -67,11 +71,11 @@ impl BrowserInstance {
         config: &LynxConfig,
         profile: &str,
         headless: bool,
+        block_images: bool,
     ) -> Result<Self, LynxError> {
         let profile_dir = config.profile_dir.join(profile);
-        std::fs::create_dir_all(&profile_dir).map_err(|e| {
-            LynxError::Browser(format!("Failed to create profile dir: {e}"))
-        })?;
+        std::fs::create_dir_all(&profile_dir)
+            .map_err(|e| LynxError::Browser(format!("Failed to create profile dir: {e}")))?;
 
         // Clean up stale lock files from unclean Chrome exits
         for lock_file in &["SingletonLock", "SingletonCookie", "SingletonSocket"] {
@@ -88,13 +92,18 @@ impl BrowserInstance {
             .arg("--no-first-run")
             .arg("--no-default-browser-check")
             .arg("--disable-blink-features=AutomationControlled")
-            .arg("--force-renderer-accessibility")
-            .window_size(1280, 900);
+            .arg("--force-renderer-accessibility");
 
         if headless {
-            builder = builder.arg("--headless=new");
+            builder = builder.arg("--headless=new").window_size(1920, 1080);
         } else {
-            builder = builder.with_head();
+            // Use a large window_size — Chrome clamps to the available screen.
+            // 3840x2160 ensures the viewport fills any Mac display at native scaling.
+            builder = builder.with_head().window_size(3840, 2160);
+        }
+
+        if block_images {
+            builder = builder.arg("--blink-settings=imagesEnabled=false");
         }
 
         let browser_config = builder
@@ -106,14 +115,35 @@ impl BrowserInstance {
             .map_err(|e| LynxError::Browser(format!("Chrome launch failed: {e}")))?;
 
         // Spawn the CDP handler as a background task
-        let handler_task = tokio::spawn(async move {
-            while let Some(_event) = handler.next().await {}
-        });
+        let handler_task =
+            tokio::spawn(async move { while let Some(_event) = handler.next().await {} });
 
         let page = browser
             .new_page("about:blank")
             .await
             .map_err(|e| LynxError::Browser(format!("New page failed: {e}")))?;
+
+        // chromiumoxide defaults the CDP viewport to 800x600 regardless of window_size.
+        // Use Emulation.setDeviceMetricsOverride to make the viewport fill the window.
+        if !headless {
+            // Query actual screen dimensions (CSS logical pixels)
+            let screen_dims: String = page
+                .evaluate(r#"JSON.stringify({w: screen.availWidth, h: screen.availHeight})"#)
+                .await
+                .ok()
+                .and_then(|v| v.into_value().ok())
+                .unwrap_or_else(|| r#"{"w":1920,"h":1080}"#.to_string());
+
+            let v: serde_json::Value = serde_json::from_str(&screen_dims)
+                .unwrap_or(serde_json::json!({"w":1920,"h":1080}));
+            let w = v["w"].as_i64().unwrap_or(1920);
+            // Subtract ~80px for Chrome UI (tabs + address bar + info bar)
+            let h = v["h"].as_i64().unwrap_or(1080) - 80;
+
+            let _ = page
+                .execute(SetDeviceMetricsOverrideParams::new(w, h, 0, false))
+                .await;
+        }
 
         let id = uuid::Uuid::new_v4().to_string();
 
@@ -124,8 +154,10 @@ impl BrowserInstance {
             page,
             ref_map: RefMap::new(),
             last_snapshot: None,
+            snapshot_version: 0,
             created_at: chrono::Utc::now(),
             headless,
+            block_images,
             handler: handler_task,
         })
     }
@@ -143,7 +175,11 @@ impl BrowserInstance {
             url: String::new(), // URL fetched async separately
             created_at: self.created_at.to_rfc3339(),
             headless: self.headless,
-            status: if self.is_alive() { "alive".to_string() } else { "dead".to_string() },
+            status: if self.is_alive() {
+                "alive".to_string()
+            } else {
+                "dead".to_string()
+            },
         }
     }
 
@@ -161,12 +197,7 @@ impl BrowserInstance {
     }
 
     async fn current_url(&self) -> String {
-        self.page
-            .url()
-            .await
-            .ok()
-            .flatten()
-            .unwrap_or_default()
+        self.page.url().await.ok().flatten().unwrap_or_default()
     }
 
     async fn current_title(&self) -> String {
@@ -194,7 +225,130 @@ impl BrowserInstance {
         let title = self.current_title().await;
         let current_url = self.current_url().await;
 
+        // Auto-detect if user intervention is needed (login forms, CAPTCHAs)
+        if let Some(reason) = self.detect_intervention_needed().await {
+            tracing::info!("Intervention needed on {current_url}: {reason}");
+            self.show_system_notification(&reason);
+            self.inject_intervention_banner(&reason).await;
+            return Ok(format!(
+                "Navigated to: {current_url}\nTitle: {title}\n⚠️ Intervention required: {reason}"
+            ));
+        }
+
         Ok(format!("Navigated to: {current_url}\nTitle: {title}"))
+    }
+
+    /// Detect if the current page requires user intervention (login, CAPTCHA, etc.)
+    async fn detect_intervention_needed(&self) -> Option<String> {
+        let js = r#"(function() {
+            var signals = [];
+
+            // Check for visible password input
+            var pwInputs = document.querySelectorAll('input[type="password"]');
+            for (var i = 0; i < pwInputs.length; i++) {
+                if (pwInputs[i].offsetParent !== null) {
+                    signals.push('password_field');
+                    break;
+                }
+            }
+
+            // Check for login-like username/email fields
+            var textInputs = document.querySelectorAll('input[type="text"], input[type="email"], input:not([type])');
+            for (var i = 0; i < textInputs.length; i++) {
+                var el = textInputs[i];
+                var name = ((el.name || '') + (el.id || '') + (el.placeholder || '') + (el.getAttribute('aria-label') || '')).toLowerCase();
+                if (/username|user.?name|email|login|sign.?in|account/i.test(name) && el.offsetParent !== null) {
+                    signals.push('login_field');
+                    break;
+                }
+            }
+
+            // Check for CAPTCHA
+            if (document.querySelector('.g-recaptcha, .h-captcha, iframe[src*="recaptcha"], iframe[src*="hcaptcha"], [class*="captcha" i], [id*="captcha" i]')) {
+                signals.push('captcha');
+            }
+
+            // Check for verification code / MFA prompts
+            var bodyText = (document.body.innerText || '').substring(0, 3000).toLowerCase();
+            if (/verification code|verify your identity|enter.{0,20}code|two.?factor|2fa|multi.?factor|mfa|one.?time.?pass|sent.{0,30}(text|sms|email|phone)/i.test(bodyText)) {
+                // Confirm there's an input for the code
+                var codeInputs = document.querySelectorAll('input[type="text"], input[type="tel"], input[type="number"], input:not([type])');
+                for (var i = 0; i < codeInputs.length; i++) {
+                    var ci = codeInputs[i];
+                    var ciName = ((ci.name || '') + (ci.id || '') + (ci.placeholder || '') + (ci.getAttribute('aria-label') || '')).toLowerCase();
+                    if (/code|token|otp|verify|pin/i.test(ciName) && ci.offsetParent !== null) {
+                        signals.push('verification_code');
+                        break;
+                    }
+                }
+                // Also flag if the page text strongly suggests verification even without a named input
+                if (!signals.includes('verification_code') && /enter.{0,10}(the |your )?(code|pin)/i.test(bodyText)) {
+                    signals.push('verification_code');
+                }
+            }
+
+            // Check page title/URL for login indicators
+            var titleUrl = (document.title + ' ' + location.href).toLowerCase();
+            if (/login|log.in|sign.in|signin|authenticate|verification/i.test(titleUrl)) {
+                signals.push('login_page');
+            }
+
+            if (signals.length === 0) return null;
+
+            // Build reason (most specific first)
+            if (signals.includes('captcha')) return 'CAPTCHA detected — please solve it manually.';
+            if (signals.includes('verification_code')) return 'Verification code required — please check your phone/email and enter the code.';
+            if (signals.includes('password_field') || (signals.includes('login_field') && signals.includes('login_page'))) {
+                return 'Login form detected — please sign in manually.';
+            }
+            if (signals.includes('login_page') && signals.includes('login_field')) {
+                return 'Login page detected — please sign in manually.';
+            }
+            return null;
+        })()"#;
+
+        let result: Option<String> = self
+            .page
+            .evaluate(js)
+            .await
+            .ok()
+            .and_then(|v| v.into_value().ok());
+
+        result
+    }
+
+    /// Fire a native macOS notification via osascript
+    fn show_system_notification(&self, message: &str) {
+        let escaped = message.replace('\\', "\\\\").replace('"', "\\\"");
+        let script = format!(
+            r#"display notification "{escaped}" with title "Lynx MCP" subtitle "User Intervention Required" sound name "Ping""#
+        );
+        let _ = std::process::Command::new("osascript")
+            .arg("-e")
+            .arg(&script)
+            .spawn();
+    }
+
+    /// Inject the bottom intervention banner (without polling — fire-and-forget)
+    async fn inject_intervention_banner(&self, message: &str) {
+        let escaped_msg = message.replace('\\', "\\\\").replace('\'', "\\'");
+        let inject_js = format!(
+            r#"(function() {{
+                var old = document.getElementById('__lynx_intervention');
+                if (old) old.remove();
+                var banner = document.createElement('div');
+                banner.id = '__lynx_intervention';
+                banner.style.cssText = 'position:fixed;bottom:0;left:0;right:0;z-index:999999;background:#e94560;color:white;padding:12px 20px;font-family:-apple-system,BlinkMacSystemFont,sans-serif;font-size:15px;display:flex;align-items:center;justify-content:space-between;box-shadow:0 -4px 12px rgba(0,0,0,0.3);';
+                banner.innerHTML = '<span>\u{{1f511}} <strong>User intervention required</strong> \u{{2014}} {escaped_msg}</span><button id="__lynx_dismiss" style="background:white;color:#e94560;border:none;padding:8px 20px;border-radius:6px;font-size:14px;cursor:pointer;font-weight:600;margin-left:16px;white-space:nowrap;">Done \u{{2713}}</button>';
+                document.body.appendChild(banner);
+                document.getElementById('__lynx_dismiss').addEventListener('click', function() {{
+                    banner.remove();
+                    window.__lynx_intervention_dismissed = true;
+                }});
+                window.__lynx_intervention_dismissed = false;
+            }})()"#
+        );
+        let _ = self.page.evaluate(inject_js).await;
     }
 
     pub async fn snapshot(
@@ -202,15 +356,17 @@ impl BrowserInstance {
         filter: Option<&str>,
         diff: bool,
         format: &str,
-        _selector: Option<&str>,
+        selector: Option<&str>,
         max_tokens: Option<usize>,
     ) -> Result<String, LynxError> {
         self.check_alive()?;
         let interactive_only = filter == Some("interactive");
 
-        let (nodes, ref_map) = snapshot::tree::build_snapshot(&self.page, interactive_only).await?;
+        let (nodes, ref_map, next_ref) =
+            snapshot::tree::build_snapshot(&self.page, interactive_only, selector).await?;
 
         self.ref_map = ref_map;
+        self.snapshot_version = next_ref;
 
         // Handle diff
         let diff_summary = if diff {
@@ -252,6 +408,7 @@ impl BrowserInstance {
                     total_refs: nodes.len(),
                     nodes,
                     diff_summary,
+                    snapshot_version: self.snapshot_version,
                 };
                 serde_json::to_string_pretty(&result)
                     .map_err(|e| LynxError::Snapshot(e.to_string()))?
@@ -281,11 +438,29 @@ impl BrowserInstance {
 
     pub async fn click(&mut self, ref_id: &str) -> Result<String, LynxError> {
         self.check_alive()?;
-        let _backend_id = *self
-            .ref_map
+        self.ref_map
             .resolve(ref_id)
             .ok_or_else(|| LynxError::ElementNotFound(ref_id.to_string()))?;
 
+        // First attempt
+        match self.click_inner(ref_id).await {
+            Ok(msg) => return Ok(msg),
+            Err(LynxError::ElementNotFound(_)) => {
+                tracing::info!("click {ref_id} missed — dismissing overlays and retrying");
+            }
+            Err(e) => return Err(e),
+        }
+
+        // Dismiss overlays that may be blocking the element
+        let _ = self.dismiss_overlays().await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+
+        // Retry once
+        self.click_inner(ref_id).await
+    }
+
+    /// Single click attempt — locate element by ref, CDP mouse click at center.
+    async fn click_inner(&self, ref_id: &str) -> Result<String, LynxError> {
         // Find element by data-lynx-ref attribute (stamped during snapshot)
         let locate_js = format!(
             r#"(function() {{
@@ -318,7 +493,7 @@ impl BrowserInstance {
 
         if locate_result == "not_found" {
             return Err(LynxError::ElementNotFound(format!(
-                "{ref_id} not found in DOM walk"
+                "{ref_id} not found in DOM"
             )));
         }
 
@@ -329,11 +504,10 @@ impl BrowserInstance {
         let tag = coords["tag"].as_str().unwrap_or("?");
         let text = coords["text"].as_str().unwrap_or("");
 
-        // Step 2: CDP trusted mouse click at element center
-        // This produces isTrusted:true events that React/Angular respect
-        let mut mouse_down = DispatchMouseEventParams::new(
-            DispatchMouseEventType::MousePressed, x, y,
-        );
+        // CDP trusted mouse click at element center
+        // Produces isTrusted:true events that React/Angular respect
+        let mut mouse_down =
+            DispatchMouseEventParams::new(DispatchMouseEventType::MousePressed, x, y);
         mouse_down.button = Some(MouseButton::Left);
         mouse_down.click_count = Some(1);
 
@@ -342,9 +516,8 @@ impl BrowserInstance {
             .await
             .map_err(|e| LynxError::Browser(format!("click mousedown failed: {e}")))?;
 
-        let mut mouse_up = DispatchMouseEventParams::new(
-            DispatchMouseEventType::MouseReleased, x, y,
-        );
+        let mut mouse_up =
+            DispatchMouseEventParams::new(DispatchMouseEventType::MouseReleased, x, y);
         mouse_up.button = Some(MouseButton::Left);
         mouse_up.click_count = Some(1);
 
@@ -354,7 +527,7 @@ impl BrowserInstance {
             .map_err(|e| LynxError::Browser(format!("click mouseup failed: {e}")))?;
 
         tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
-        Ok(format!("Clicked {ref_id} (clicked:{tag}:{text})"))
+        Ok(format!("Clicked {ref_id} ({tag}:{text})"))
     }
 
     pub async fn type_text(
@@ -369,7 +542,10 @@ impl BrowserInstance {
             .resolve(ref_id)
             .ok_or_else(|| LynxError::ElementNotFound(ref_id.to_string()))?;
 
-        let escaped_text = text.replace('\\', "\\\\").replace('\'', "\\'").replace('\n', "\\n");
+        let escaped_text = text
+            .replace('\\', "\\\\")
+            .replace('\'', "\\'")
+            .replace('\n', "\\n");
         let clear_flag = if clear_first { "true" } else { "false" };
 
         // Find element by data-lynx-ref (stamped during snapshot), focus, type
@@ -453,11 +629,7 @@ impl BrowserInstance {
         Ok(format!("Typed into {ref_id} via {method}: {text}"))
     }
 
-    pub async fn press(
-        &mut self,
-        ref_id: &str,
-        key: &str,
-    ) -> Result<String, LynxError> {
+    pub async fn press(&mut self, ref_id: &str, key: &str) -> Result<String, LynxError> {
         self.check_alive()?;
         let _backend_id = *self
             .ref_map
@@ -521,9 +693,84 @@ impl BrowserInstance {
         }
     }
 
-    pub async fn upload_file(&self, _file_paths: &[String]) -> Result<String, LynxError> {
-        // TODO: implement CDP DOM.setFileInputFiles
-        Ok("File upload not yet implemented".to_string())
+    pub async fn upload_file(
+        &self,
+        ref_id: Option<&str>,
+        file_paths: &[String],
+    ) -> Result<String, LynxError> {
+        self.check_alive()?;
+
+        // Validate file paths exist locally
+        for path in file_paths {
+            if !std::path::Path::new(path).exists() {
+                return Err(LynxError::Browser(format!("File not found: {path}")));
+            }
+        }
+
+        // Find the file input element — by ref or first input[type=file]
+        let selector = if let Some(rid) = ref_id {
+            self.ref_map
+                .resolve(rid)
+                .ok_or_else(|| LynxError::ElementNotFound(rid.to_string()))?;
+            format!("[data-lynx-ref=\"{rid}\"]")
+        } else {
+            "input[type=file]".to_string()
+        };
+
+        // Get a RemoteObjectId for the file input via JS evaluation
+        use chromiumoxide::cdp::browser_protocol::dom::SetFileInputFilesParams;
+        use chromiumoxide::cdp::js_protocol::runtime::EvaluateParams;
+
+        let eval_js = format!(
+            r#"(function() {{
+                var el = document.querySelector('{selector}');
+                if (!el) return null;
+                if (el.tagName !== 'INPUT' || el.type !== 'file') {{
+                    var nested = el.querySelector('input[type=file]');
+                    if (nested) return nested;
+                    return null;
+                }}
+                return el;
+            }})()"#
+        );
+
+        let mut eval_params = EvaluateParams::new(eval_js);
+        eval_params.return_by_value = Some(false);
+
+        let eval_result = self
+            .page
+            .execute(eval_params)
+            .await
+            .map_err(|e| LynxError::Browser(format!("upload locate failed: {e}")))?;
+
+        let remote_object = &eval_result.result.result;
+        let object_id = remote_object
+            .object_id
+            .as_ref()
+            .ok_or_else(|| {
+                LynxError::ElementNotFound("No file input element found on page".to_string())
+            })?
+            .clone();
+
+        // Set files via CDP DOM.setFileInputFiles
+        let mut params = SetFileInputFilesParams::new(file_paths.to_vec());
+        params.object_id = Some(object_id);
+
+        self.page
+            .execute(params)
+            .await
+            .map_err(|e| LynxError::Browser(format!("setFileInputFiles failed: {e}")))?;
+
+        let file_names: Vec<&str> = file_paths
+            .iter()
+            .filter_map(|p| std::path::Path::new(p).file_name().and_then(|n| n.to_str()))
+            .collect();
+
+        Ok(format!(
+            "Uploaded {} file(s): {}",
+            file_paths.len(),
+            file_names.join(", ")
+        ))
     }
 
     pub async fn eval(&self, expression: &str) -> Result<String, LynxError> {
@@ -546,8 +793,7 @@ impl BrowserInstance {
             .into_value()
             .map_err(|e| LynxError::JsEval(format!("{e:?}")))?;
 
-        serde_json::to_string_pretty(&result)
-            .map_err(|e| LynxError::JsEval(e.to_string()))
+        serde_json::to_string_pretty(&result).map_err(|e| LynxError::JsEval(e.to_string()))
     }
 
     pub async fn dismiss_overlays(&self) -> Result<String, LynxError> {
@@ -621,7 +867,9 @@ impl BrowserInstance {
             tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
         }
 
-        Ok(format!("Timeout after {timeout_ms}ms (may still be loading)"))
+        Ok(format!(
+            "Timeout after {timeout_ms}ms (may still be loading)"
+        ))
     }
 
     pub async fn screenshot(&self, full_page: bool) -> Result<String, LynxError> {
@@ -654,6 +902,55 @@ impl BrowserInstance {
         Ok(base64::engine::general_purpose::STANDARD.encode(&bytes))
     }
 
+    /// Show a non-blocking intervention banner at the bottom of the page.
+    /// Fires a native macOS notification, then polls until the user clicks "Done" or timeout expires.
+    pub async fn request_intervention(
+        &self,
+        message: &str,
+        timeout_ms: u64,
+    ) -> Result<String, LynxError> {
+        self.check_alive()?;
+
+        // System notification + browser banner
+        self.show_system_notification(message);
+        self.inject_intervention_banner(message).await;
+
+        // Poll for dismiss
+        let start = std::time::Instant::now();
+        let timeout = std::time::Duration::from_millis(timeout_ms);
+
+        while start.elapsed() < timeout {
+            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+            let dismissed: bool = self
+                .page
+                .evaluate("window.__lynx_intervention_dismissed === true")
+                .await
+                .map_err(|e| LynxError::Browser(format!("intervention poll failed: {e}")))?
+                .into_value()
+                .unwrap_or(false);
+
+            if dismissed {
+                return Ok(format!(
+                    "User completed intervention after {}ms",
+                    start.elapsed().as_millis()
+                ));
+            }
+        }
+
+        // Timeout — clean up banner
+        let _ = self
+            .page
+            .evaluate(
+                "(function(){ var b = document.getElementById('__lynx_intervention'); if (b) b.remove(); })()",
+            )
+            .await;
+
+        Ok(format!(
+            "Intervention timed out after {timeout_ms}ms (user did not click Done)"
+        ))
+    }
+
     pub async fn auth_login(
         &mut self,
         item: &str,
@@ -666,10 +963,12 @@ impl BrowserInstance {
         // Navigate to login page
         self.navigate(url, 3000).await?;
 
-        // TODO: implement iterative form fill using snapshot + ref resolution
-        // For now, return the credential fetch status
+        // Run iterative form fill
+        let fill_result = crate::auth::form_fill::fill_login_form(self, &creds).await?;
+
+        let current_url = self.current_url().await;
         Ok(format!(
-            "Auth: navigated to {url}, credentials loaded for '{}' (user: {})",
+            "Auth login for '{}' (user: {})\nURL: {current_url}\n{fill_result}",
             item, creds.username
         ))
     }

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -17,6 +17,7 @@ struct DeadInstanceInfo {
     id: InstanceId,
     profile: String,
     headless: bool,
+    block_images: bool,
 }
 
 impl Default for BrowserManager {
@@ -44,6 +45,7 @@ impl BrowserManager {
                 id: inst.id.clone(),
                 profile: inst.profile.clone(),
                 headless: inst.headless,
+                block_images: inst.block_images,
             }),
             _ => None,
         }
@@ -55,16 +57,19 @@ impl BrowserManager {
         if let Some(dead) = self.check_dead(id) {
             tracing::warn!(
                 "Instance '{}' is dead — auto-recovering with profile '{}'",
-                dead.id, dead.profile
+                dead.id,
+                dead.profile
             );
             // Remove the dead instance
             self.instances.remove(&dead.id);
-            // Relaunch with same profile and headless setting
+            // Relaunch with same profile, headless, and block_images settings
             let new_inst = instance::BrowserInstance::launch(
                 &self.config,
                 &dead.profile,
                 dead.headless,
-            ).await?;
+                dead.block_images,
+            )
+            .await?;
             // Keep the same ID so callers don't need to update references
             let mut recovered = new_inst;
             recovered.id = dead.id.clone();
@@ -112,8 +117,10 @@ impl BrowserManager {
         &mut self,
         profile: &str,
         headless: bool,
+        block_images: bool,
     ) -> Result<String, LynxError> {
-        let inst = instance::BrowserInstance::launch(&self.config, profile, headless).await?;
+        let inst = instance::BrowserInstance::launch(&self.config, profile, headless, block_images)
+            .await?;
         let id = inst.id.clone();
         self.instances.insert(id.clone(), inst);
         Ok(id)
@@ -145,7 +152,6 @@ impl BrowserManager {
         &mut self,
         id: &Option<String>,
         url: &str,
-        _block_images: bool,
         wait_ms: u64,
     ) -> Result<String, LynxError> {
         self.recover_if_dead(id).await?;
@@ -168,7 +174,11 @@ impl BrowserManager {
             .await
     }
 
-    pub async fn text(&mut self, id: &Option<String>, max_tokens: usize) -> Result<String, LynxError> {
+    pub async fn text(
+        &mut self,
+        id: &Option<String>,
+        max_tokens: usize,
+    ) -> Result<String, LynxError> {
         self.recover_if_dead(id).await?;
         let inst = self.get_instance(id)?;
         inst.text(max_tokens).await
@@ -206,11 +216,12 @@ impl BrowserManager {
     pub async fn upload_file(
         &mut self,
         id: &Option<String>,
+        ref_id: Option<&str>,
         file_paths: &[String],
     ) -> Result<String, LynxError> {
         self.recover_if_dead(id).await?;
         let inst = self.get_instance(id)?;
-        inst.upload_file(file_paths).await
+        inst.upload_file(ref_id, file_paths).await
     }
 
     pub async fn eval(
@@ -253,6 +264,17 @@ impl BrowserManager {
         self.recover_if_dead(id).await?;
         let inst = self.get_instance(id)?;
         inst.pdf().await
+    }
+
+    pub async fn request_intervention(
+        &mut self,
+        id: &Option<String>,
+        message: &str,
+        timeout_ms: u64,
+    ) -> Result<String, LynxError> {
+        self.recover_if_dead(id).await?;
+        let inst = self.get_instance(id)?;
+        inst.request_intervention(message, timeout_ms).await
     }
 
     pub async fn auth_login(

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,17 +26,11 @@ pub enum LynxError {
     #[error("Auth provider error: {0}")]
     AuthProvider(String),
 
-    #[error("Auth failed: {0}")]
-    Auth(String),
-
     #[error("Screenshot failed: {0}")]
     Screenshot(String),
 
     #[error("PDF export failed: {0}")]
     Pdf(String),
-
-    #[error("Chrome not found at {0}")]
-    ChromeNotFound(String),
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
+pub mod auth;
 pub mod browser;
 pub mod error;
 pub mod server;
 pub mod snapshot;
-pub mod auth;
 pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-//! lynx4ai — Rust MCP server for AI browser automation.
+//! lynx-mcp — Rust MCP server for AI browser automation.
 //!
 //! Communicates via stdio (MCP protocol). All logging goes to stderr.
 //! NEVER use println!() — it corrupts the MCP JSON-RPC stream on stdout.
@@ -18,18 +18,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize tracing to STDERR only (critical for MCP stdio transport)
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| "lynx4ai=info".into()),
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| "lynx_mcp=info".into()),
         )
         .with_writer(std::io::stderr)
         .init();
 
-    tracing::info!("lynx4ai starting");
+    tracing::info!("lynx-mcp starting");
 
     let transport = rmcp::transport::io::stdio();
     let service = server::LynxServer::new().serve(transport).await?;
 
     service.waiting().await?;
 
-    tracing::info!("lynx4ai shutting down");
+    tracing::info!("lynx-mcp shutting down");
     Ok(())
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,7 +4,7 @@ use tokio::sync::RwLock;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::*;
-use rmcp::{tool, tool_handler, tool_router, ServerHandler};
+use rmcp::{ServerHandler, tool, tool_handler, tool_router};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -18,6 +18,8 @@ pub struct InstanceCreateParams {
     pub profile: Option<String>,
     /// Run in headless mode (default: true). Set false for visible Chrome.
     pub headless: Option<bool>,
+    /// Block all image loading for faster page loads (default: false).
+    pub block_images: Option<bool>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -32,8 +34,6 @@ pub struct NavigateParams {
     pub url: String,
     /// Instance ID (uses default if omitted)
     pub instance_id: Option<String>,
-    /// Block image loading for speed
-    pub block_images: Option<bool>,
     /// Extra wait in ms after navigation (default: 2000)
     pub wait_ms: Option<u64>,
 }
@@ -94,6 +94,8 @@ pub struct PressParams {
 
 #[derive(Deserialize, JsonSchema)]
 pub struct UploadFileParams {
+    /// Element ref for file input (e.g., "e5"). If omitted, finds first input[type=file].
+    pub ref_id: Option<String>,
     /// Local file path(s), comma-separated for multiple
     pub file_paths: String,
     /// Instance ID (uses default if omitted)
@@ -128,6 +130,16 @@ pub struct ScreenshotParams {
     pub instance_id: Option<String>,
     /// Capture full scrollable page
     pub full_page: Option<bool>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct RequestInterventionParams {
+    /// Message explaining what the user needs to do (e.g., "Please sign in manually")
+    pub message: String,
+    /// Instance ID (uses default if omitted)
+    pub instance_id: Option<String>,
+    /// Timeout in ms waiting for user to click Done (default: 120000 = 2 min)
+    pub timeout_ms: Option<u64>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -167,18 +179,25 @@ impl LynxServer {
 
 #[tool_router(router = tool_router)]
 impl LynxServer {
-    #[tool(description = "Create a new browser instance with persistent Chrome profile. Returns instance ID.")]
+    #[tool(
+        description = "Create a new browser instance with persistent Chrome profile. Returns instance ID."
+    )]
     async fn instance_create(&self, Parameters(p): Parameters<InstanceCreateParams>) -> String {
         let profile = p.profile.unwrap_or_else(|| "default".to_string());
         let headless = p.headless.unwrap_or(true);
+        let block_images = p.block_images.unwrap_or(false);
         let mut mgr = self.manager.write().await;
-        match mgr.create_instance(&profile, headless).await {
-            Ok(id) => format!("Instance created: {id}\nProfile: {profile}\nHeadless: {headless}"),
+        match mgr.create_instance(&profile, headless, block_images).await {
+            Ok(id) => format!(
+                "Instance created: {id}\nProfile: {profile}\nHeadless: {headless}\nBlock images: {block_images}"
+            ),
             Err(e) => format!("Error: {e}"),
         }
     }
 
-    #[tool(description = "List all running browser instances with their IDs, profiles, and current URLs.")]
+    #[tool(
+        description = "List all running browser instances with their IDs, profiles, and current URLs."
+    )]
     async fn instance_list(&self) -> String {
         let mgr = self.manager.read().await;
         let instances = mgr.list_instances();
@@ -197,19 +216,36 @@ impl LynxServer {
         }
     }
 
-    #[tool(description = "Navigate to a URL. Waits for page load + accessibility tree. Returns page title and URL.")]
+    #[tool(
+        description = "Navigate to a URL. Waits for page load + accessibility tree. Returns page title and URL."
+    )]
     async fn navigate(&self, Parameters(p): Parameters<NavigateParams>) -> String {
         let mut mgr = self.manager.write().await;
-        match mgr.navigate(&p.instance_id, &p.url, p.block_images.unwrap_or(false), p.wait_ms.unwrap_or(2000)).await {
+        match mgr
+            .navigate(&p.instance_id, &p.url, p.wait_ms.unwrap_or(2000))
+            .await
+        {
             Ok(info) => info,
             Err(e) => format!("Error: {e}"),
         }
     }
 
-    #[tool(description = "Get accessibility tree snapshot with stable element refs (e0, e1, e2...). Use filter='interactive' for only clickable/typeable elements. Use diff=true for changes since last snapshot. Use format='compact' for fewer tokens.")]
+    #[tool(
+        description = "Get accessibility tree snapshot with stable element refs (e0, e1, e2...). Use filter='interactive' for only clickable/typeable elements. Use diff=true for changes since last snapshot. Use format='compact' for fewer tokens."
+    )]
     async fn snapshot(&self, Parameters(p): Parameters<SnapshotParams>) -> String {
         let mut mgr = self.manager.write().await;
-        match mgr.snapshot(&p.instance_id, p.filter.as_deref(), p.diff.unwrap_or(false), p.format.as_deref().unwrap_or("full"), p.selector.as_deref(), p.max_tokens.map(|v| v as usize)).await {
+        match mgr
+            .snapshot(
+                &p.instance_id,
+                p.filter.as_deref(),
+                p.diff.unwrap_or(false),
+                p.format.as_deref().unwrap_or("full"),
+                p.selector.as_deref(),
+                p.max_tokens.map(|v| v as usize),
+            )
+            .await
+        {
             Ok(result) => result,
             Err(e) => format!("Error: {e}"),
         }
@@ -218,13 +254,18 @@ impl LynxServer {
     #[tool(description = "Extract readable text from the page (~800 tokens by default).")]
     async fn text(&self, Parameters(p): Parameters<TextParams>) -> String {
         let mut mgr = self.manager.write().await;
-        match mgr.text(&p.instance_id, p.max_tokens.unwrap_or(800) as usize).await {
+        match mgr
+            .text(&p.instance_id, p.max_tokens.unwrap_or(800) as usize)
+            .await
+        {
             Ok(text) => text,
             Err(e) => format!("Error: {e}"),
         }
     }
 
-    #[tool(description = "Click an element by its ref ID from snapshot (e.g., 'e5'). Auto-dismisses overlays and retries.")]
+    #[tool(
+        description = "Click an element by its ref ID from snapshot (e.g., 'e5'). If obscured, dismisses overlays and retries once."
+    )]
     async fn click(&self, Parameters(p): Parameters<ClickParams>) -> String {
         let mut mgr = self.manager.write().await;
         match mgr.click(&p.instance_id, &p.ref_id).await {
@@ -236,13 +277,23 @@ impl LynxServer {
     #[tool(description = "Type text into an element by its ref ID.")]
     async fn type_text(&self, Parameters(p): Parameters<TypeTextParams>) -> String {
         let mut mgr = self.manager.write().await;
-        match mgr.type_text(&p.instance_id, &p.ref_id, &p.text, p.clear_first.unwrap_or(false)).await {
+        match mgr
+            .type_text(
+                &p.instance_id,
+                &p.ref_id,
+                &p.text,
+                p.clear_first.unwrap_or(false),
+            )
+            .await
+        {
             Ok(msg) => msg,
             Err(e) => format!("Error: {e}"),
         }
     }
 
-    #[tool(description = "Press a keyboard key on an element (Enter, Tab, Escape, ArrowDown, etc.).")]
+    #[tool(
+        description = "Press a keyboard key on an element (Enter, Tab, Escape, ArrowDown, etc.)."
+    )]
     async fn press(&self, Parameters(p): Parameters<PressParams>) -> String {
         let mut mgr = self.manager.write().await;
         match mgr.press(&p.instance_id, &p.ref_id, &p.key).await {
@@ -251,11 +302,20 @@ impl LynxServer {
         }
     }
 
-    #[tool(description = "Upload file(s) via a file input element on the page. Comma-separate multiple paths.")]
+    #[tool(
+        description = "Upload file(s) via a file input element on the page. Comma-separate multiple paths."
+    )]
     async fn upload_file(&self, Parameters(p): Parameters<UploadFileParams>) -> String {
-        let paths: Vec<String> = p.file_paths.split(',').map(|s| s.trim().to_string()).collect();
+        let paths: Vec<String> = p
+            .file_paths
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .collect();
         let mut mgr = self.manager.write().await;
-        match mgr.upload_file(&p.instance_id, &paths).await {
+        match mgr
+            .upload_file(&p.instance_id, p.ref_id.as_deref(), &paths)
+            .await
+        {
             Ok(msg) => msg,
             Err(e) => format!("Error: {e}"),
         }
@@ -279,10 +339,15 @@ impl LynxServer {
         }
     }
 
-    #[tool(description = "Wait until page content stabilizes (text stops changing, no loading spinners).")]
+    #[tool(
+        description = "Wait until page content stabilizes (text stops changing, no loading spinners)."
+    )]
     async fn wait_for_stable(&self, Parameters(p): Parameters<WaitForStableParams>) -> String {
         let mut mgr = self.manager.write().await;
-        match mgr.wait_for_stable(&p.instance_id, p.timeout_ms.unwrap_or(10000)).await {
+        match mgr
+            .wait_for_stable(&p.instance_id, p.timeout_ms.unwrap_or(10000))
+            .await
+        {
             Ok(msg) => msg,
             Err(e) => format!("Error: {e}"),
         }
@@ -291,7 +356,10 @@ impl LynxServer {
     #[tool(description = "Take a page screenshot. Returns base64-encoded PNG.")]
     async fn screenshot(&self, Parameters(p): Parameters<ScreenshotParams>) -> String {
         let mut mgr = self.manager.write().await;
-        match mgr.screenshot(&p.instance_id, p.full_page.unwrap_or(false)).await {
+        match mgr
+            .screenshot(&p.instance_id, p.full_page.unwrap_or(false))
+            .await
+        {
             Ok(b64) => format!("data:image/png;base64,{b64}"),
             Err(e) => format!("Error: {e}"),
         }
@@ -306,10 +374,32 @@ impl LynxServer {
         }
     }
 
-    #[tool(description = "Log into a website using credentials from a password manager (1Password by default). Handles multi-page login flows with username, password, and optional TOTP.")]
+    #[tool(
+        description = "Log into a website using credentials from a password manager (1Password by default). Handles multi-page login flows with username, password, and optional TOTP."
+    )]
     async fn auth_login(&self, Parameters(p): Parameters<AuthLoginParams>) -> String {
         let mut mgr = self.manager.write().await;
-        match mgr.auth_login(&p.instance_id, &p.item, &p.url, p.vault.as_deref()).await {
+        match mgr
+            .auth_login(&p.instance_id, &p.item, &p.url, p.vault.as_deref())
+            .await
+        {
+            Ok(msg) => msg,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    #[tool(
+        description = "Show a non-blocking banner in the browser asking the user to intervene (e.g., solve a CAPTCHA, log in manually). The page remains fully interactive. Waits for the user to click 'Done' or times out."
+    )]
+    async fn request_intervention(
+        &self,
+        Parameters(p): Parameters<RequestInterventionParams>,
+    ) -> String {
+        let mut mgr = self.manager.write().await;
+        match mgr
+            .request_intervention(&p.instance_id, &p.message, p.timeout_ms.unwrap_or(120_000))
+            .await
+        {
             Ok(msg) => msg,
             Err(e) => format!("Error: {e}"),
         }
@@ -319,16 +409,11 @@ impl LynxServer {
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for LynxServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            instructions: Some(
-                "lynx4ai: AI browser automation via Chrome accessibility tree. \
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_instructions(
+            "lynx-mcp: AI browser automation via Chrome accessibility tree. \
                  Create a browser instance, navigate to pages, snapshot the accessibility tree \
                  with stable element refs, interact via click/type/press, and authenticate \
-                 via password manager. Inspired by the original Lynx text browser (1992)."
-                    .into(),
-            ),
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            ..Default::default()
-        }
+                 via password manager. Inspired by the original Lynx text browser (1992).",
+        )
     }
 }

--- a/src/snapshot/compact.rs
+++ b/src/snapshot/compact.rs
@@ -5,10 +5,7 @@ use crate::types::SnapshotNode;
 /// This is 56-64% fewer tokens than full JSON
 pub fn render_compact(nodes: &[SnapshotNode], lines: &mut Vec<String>) {
     for node in nodes {
-        let mut parts = vec![
-            node.ref_id.clone(),
-            format!("[{}]", node.role),
-        ];
+        let mut parts = vec![node.ref_id.clone(), format!("[{}]", node.role)];
 
         if !node.name.is_empty() {
             parts.push(format!("\"{}\"", node.name));
@@ -28,5 +25,73 @@ pub fn render_compact(nodes: &[SnapshotNode], lines: &mut Vec<String>) {
         if !node.children.is_empty() {
             render_compact(&node.children, lines);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(ref_id: &str, role: &str, name: &str, interactive: bool) -> SnapshotNode {
+        SnapshotNode {
+            ref_id: ref_id.to_string(),
+            role: role.to_string(),
+            name: name.to_string(),
+            description: None,
+            value: None,
+            interactive,
+            children: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn basic_render() {
+        let nodes = vec![
+            node("e0", "button", "Submit", true),
+            node("e1", "heading", "Welcome", false),
+        ];
+        let mut lines = Vec::new();
+        render_compact(&nodes, &mut lines);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0], r#"e0 [button] "Submit" interactive"#);
+        assert_eq!(lines[1], r#"e1 [heading] "Welcome""#);
+    }
+
+    #[test]
+    fn with_value() {
+        let mut n = node("e0", "textbox", "Email", true);
+        n.value = Some("test@example.com".to_string());
+        let mut lines = Vec::new();
+        render_compact(&[n], &mut lines);
+        assert!(lines[0].contains(r#"val="test@example.com""#));
+    }
+
+    #[test]
+    fn empty_name_omitted() {
+        let n = node("e0", "generic", "", false);
+        let mut lines = Vec::new();
+        render_compact(&[n], &mut lines);
+        assert_eq!(lines[0], "e0 [generic]");
+    }
+
+    #[test]
+    fn children_rendered() {
+        let mut parent = node("e0", "list", "Nav", false);
+        parent.children = vec![
+            node("e1", "listitem", "Home", false),
+            node("e2", "listitem", "About", false),
+        ];
+        let mut lines = Vec::new();
+        render_compact(&[parent], &mut lines);
+        assert_eq!(lines.len(), 3);
+        assert!(lines[1].starts_with("e1"));
+        assert!(lines[2].starts_with("e2"));
+    }
+
+    #[test]
+    fn empty_nodes() {
+        let mut lines = Vec::new();
+        render_compact(&[], &mut lines);
+        assert!(lines.is_empty());
     }
 }

--- a/src/snapshot/diff.rs
+++ b/src/snapshot/diff.rs
@@ -34,17 +34,126 @@ pub fn compute_diff(previous: &[SnapshotNode], current: &[SnapshotNode]) -> Stri
 
     let mut lines = Vec::new();
     if !added.is_empty() {
-        lines.push(format!("Added: {}", added.iter().map(|r| r.as_str()).collect::<Vec<_>>().join(", ")));
+        lines.push(format!(
+            "Added: {}",
+            added
+                .iter()
+                .map(|r| r.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
     }
     if !removed.is_empty() {
-        lines.push(format!("Removed: {}", removed.iter().map(|r| r.as_str()).collect::<Vec<_>>().join(", ")));
+        lines.push(format!(
+            "Removed: {}",
+            removed
+                .iter()
+                .map(|r| r.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
     }
     if !changed.is_empty() {
-        lines.push(format!("Changed: {}", changed.iter().map(|r| r.as_str()).collect::<Vec<_>>().join(", ")));
+        lines.push(format!(
+            "Changed: {}",
+            changed
+                .iter()
+                .map(|r| r.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
     }
     if lines.is_empty() {
         lines.push("No changes detected".to_string());
     }
 
     lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(ref_id: &str, role: &str, name: &str) -> SnapshotNode {
+        SnapshotNode {
+            ref_id: ref_id.to_string(),
+            role: role.to_string(),
+            name: name.to_string(),
+            description: None,
+            value: None,
+            interactive: false,
+            children: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn no_changes() {
+        let a = vec![node("e0", "button", "OK")];
+        let b = vec![node("e0", "button", "OK")];
+        assert_eq!(compute_diff(&a, &b), "No changes detected");
+    }
+
+    #[test]
+    fn added_node() {
+        let a = vec![node("e0", "button", "OK")];
+        let b = vec![node("e0", "button", "OK"), node("e5", "link", "Help")];
+        let diff = compute_diff(&a, &b);
+        assert!(diff.contains("Added: e5"));
+        assert!(!diff.contains("Removed"));
+        assert!(!diff.contains("Changed"));
+    }
+
+    #[test]
+    fn removed_node() {
+        let a = vec![node("e0", "button", "OK"), node("e3", "link", "Help")];
+        let b = vec![node("e0", "button", "OK")];
+        let diff = compute_diff(&a, &b);
+        assert!(diff.contains("Removed: e3"));
+    }
+
+    #[test]
+    fn changed_name() {
+        let a = vec![node("e0", "button", "Submit")];
+        let b = vec![node("e0", "button", "Loading...")];
+        let diff = compute_diff(&a, &b);
+        assert!(diff.contains("Changed: e0"));
+    }
+
+    #[test]
+    fn changed_role() {
+        let a = vec![node("e0", "button", "X")];
+        let b = vec![node("e0", "link", "X")];
+        let diff = compute_diff(&a, &b);
+        assert!(diff.contains("Changed: e0"));
+    }
+
+    #[test]
+    fn changed_value() {
+        let mut a = node("e0", "textbox", "Email");
+        a.value = Some("old@test.com".to_string());
+        let mut b = node("e0", "textbox", "Email");
+        b.value = Some("new@test.com".to_string());
+        let diff = compute_diff(&[a], &[b]);
+        assert!(diff.contains("Changed: e0"));
+    }
+
+    #[test]
+    fn sparse_refs_stable() {
+        // Simulates persistent refs: e0 stays, e3 stays, e7 is new
+        let a = vec![node("e0", "button", "OK"), node("e3", "link", "Home")];
+        let b = vec![
+            node("e0", "button", "OK"),
+            node("e3", "link", "Home"),
+            node("e7", "textbox", "Search"),
+        ];
+        let diff = compute_diff(&a, &b);
+        assert!(diff.contains("Added: e7"));
+        assert!(!diff.contains("Changed"));
+        assert!(!diff.contains("Removed"));
+    }
+
+    #[test]
+    fn both_empty() {
+        assert_eq!(compute_diff(&[], &[]), "No changes detected");
+    }
 }

--- a/src/snapshot/tree.rs
+++ b/src/snapshot/tree.rs
@@ -4,38 +4,18 @@ use crate::browser::instance::RefMap;
 use crate::error::LynxError;
 use crate::types::SnapshotNode;
 
-/// Interactive accessibility roles
-const INTERACTIVE_ROLES: &[&str] = &[
-    "button",
-    "link",
-    "textbox",
-    "checkbox",
-    "radio",
-    "combobox",
-    "listbox",
-    "menuitem",
-    "menuitemcheckbox",
-    "menuitemradio",
-    "option",
-    "searchbox",
-    "slider",
-    "spinbutton",
-    "switch",
-    "tab",
-    "treeitem",
-];
-
-#[allow(dead_code)]
-fn is_interactive(role: &str) -> bool {
-    INTERACTIVE_ROLES.contains(&role.to_lowercase().as_str())
-}
-
 /// JavaScript that walks the DOM and extracts accessibility info.
 /// Uses computedRole/computedName (Chrome 90+) with aria-* fallbacks.
 /// Stamps each matched element with data-lynx-ref="eN" for click/type resolution.
-/// Returns JSON array including the ref index so Rust uses the SAME indices.
-const JS_SNAPSHOT: &str = r#"
-(function() {
+///
+/// Refs are **persistent and monotonic**: once an element is stamped with eN, it keeps
+/// that ref across subsequent snapshots. New elements get the next available ref from
+/// `window.__lynx_next_ref`. Removed elements naturally lose their stamp.
+///
+/// The `__LYNX_SELECTOR__` placeholder is replaced by Rust with a CSS selector string
+/// or `null` to scope the snapshot to a subtree.
+const JS_SNAPSHOT_TEMPLATE: &str = r#"
+(function(rootSelector) {
     const INTERACTIVE_TAGS = new Set(['A','BUTTON','INPUT','SELECT','TEXTAREA','DETAILS','SUMMARY']);
     const INTERACTIVE_ROLES = new Set([
         'button','link','textbox','checkbox','radio','combobox','listbox',
@@ -95,14 +75,17 @@ const JS_SNAPSHOT: &str = r#"
         return text.trim().substring(0, 100);
     }
 
-    // Clean up any previous ref tags
-    document.querySelectorAll('[data-lynx-ref]').forEach(function(e) {
-        e.removeAttribute('data-lynx-ref');
-    });
+    // Persistent monotonic counter — never resets across snapshots
+    if (typeof window.__lynx_next_ref === 'undefined') {
+        window.__lynx_next_ref = 0;
+    }
+
+    // Scope to selector subtree or full body
+    var root = rootSelector ? document.querySelector(rootSelector) : document.body;
+    if (!root) root = document.body;
 
     var nodes = [];
-    var refIdx = 0;
-    var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, null);
+    var walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, null);
     var el = walker.currentNode;
     while (el) {
         if (!SKIP_TAGS.has(el.tagName)) {
@@ -112,16 +95,24 @@ const JS_SNAPSHOT: &str = r#"
                 var interactive = INTERACTIVE_TAGS.has(el.tagName) || INTERACTIVE_ROLES.has(role);
                 var value = el.value !== undefined && el.value !== '' ? String(el.value) : undefined;
                 var desc = el.getAttribute('aria-description') || undefined;
-                // Stamp the DOM element so click/type_text can find it by ref
-                el.setAttribute('data-lynx-ref', 'e' + refIdx);
+
+                // Persistent ref: keep existing stamp, only assign new refs to unstamped elements
+                var existingRef = el.getAttribute('data-lynx-ref');
+                var refIdx;
+                if (existingRef) {
+                    refIdx = parseInt(existingRef.substring(1), 10);
+                } else {
+                    refIdx = window.__lynx_next_ref++;
+                    el.setAttribute('data-lynx-ref', 'e' + refIdx);
+                }
+
                 nodes.push({ role: role, name: name, interactive: interactive, value: value, desc: desc, tag: el.tagName, r: refIdx });
-                refIdx++;
             }
         }
         el = walker.nextNode();
     }
-    return JSON.stringify(nodes);
-})()
+    return JSON.stringify({ nodes: nodes, nextRef: window.__lynx_next_ref });
+})(__LYNX_SELECTOR__)
 "#;
 
 /// Build a snapshot of the page's accessibility tree.
@@ -129,27 +120,39 @@ const JS_SNAPSHOT: &str = r#"
 /// The JS walk is the sole source of truth for ref numbering — this guarantees
 /// snapshot refs match the DOM stamps that click/type_text/press use via querySelector.
 ///
+/// Refs are persistent: elements keep their ref across snapshots. New elements get
+/// monotonically increasing refs. Returns (nodes, ref_map, snapshot_version).
+///
 /// Previous architecture used CDP getFullAXTree as primary path, but the AX tree
 /// traversal order differs from DOM document order, causing ref index mismatches
 /// when JS_TAG_ELEMENTS stamped elements in DOM order. Eliminated entirely.
 pub async fn build_snapshot(
     page: &Page,
     interactive_only: bool,
-) -> Result<(Vec<SnapshotNode>, RefMap), LynxError> {
+    selector: Option<&str>,
+) -> Result<(Vec<SnapshotNode>, RefMap, u64), LynxError> {
+    // Inject the selector into the JS template
+    let js = if let Some(sel) = selector {
+        let escaped = sel.replace('\\', "\\\\").replace('\'', "\\'");
+        JS_SNAPSHOT_TEMPLATE.replace("__LYNX_SELECTOR__", &format!("'{escaped}'"))
+    } else {
+        JS_SNAPSHOT_TEMPLATE.replace("__LYNX_SELECTOR__", "null")
+    };
+
     let json_str: String = page
-        .evaluate(JS_SNAPSHOT)
+        .evaluate(js)
         .await
         .map_err(|e| LynxError::Snapshot(format!("JS snapshot failed: {e}")))?
         .into_value()
         .map_err(|e| LynxError::Snapshot(format!("JS snapshot parse failed: {e:?}")))?;
 
-    let raw_nodes: Vec<JsNode> = serde_json::from_str(&json_str)
+    let result: JsSnapshotResult = serde_json::from_str(&json_str)
         .map_err(|e| LynxError::Snapshot(format!("JS snapshot JSON parse failed: {e}")))?;
 
     let mut ref_map = RefMap::new();
     let mut snapshot_nodes = Vec::new();
 
-    for node in raw_nodes {
+    for node in result.nodes {
         let interactive = node.interactive;
 
         if interactive_only && !interactive {
@@ -174,7 +177,14 @@ pub async fn build_snapshot(
         });
     }
 
-    Ok((snapshot_nodes, ref_map))
+    Ok((snapshot_nodes, ref_map, result.next_ref))
+}
+
+#[derive(serde::Deserialize)]
+struct JsSnapshotResult {
+    nodes: Vec<JsNode>,
+    #[serde(rename = "nextRef")]
+    next_ref: u64,
 }
 
 #[derive(serde::Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -40,6 +40,8 @@ pub struct SnapshotResult {
     pub diff_summary: Option<String>,
     pub total_refs: usize,
     pub interactive_refs: usize,
+    /// Monotonic snapshot version — increases each snapshot. Refs are stable across versions.
+    pub snapshot_version: u64,
 }
 
 /// Instance metadata for list_instances


### PR DESCRIPTION
## Summary
- Full rename from lynx4ai to lynx-mcp across all files
- All 5 code review findings fixed (3 HIGH, 2 MEDIUM)
- Added `request_intervention` tool with auto-detection + macOS notification
- Full-screen viewport via CDP `SetDeviceMetricsOverride`
- 20 unit tests added (from zero)

## Changes
- **Persistent monotonic refs** — refs survive across snapshots
- **Click retry** with overlay dismiss
- **Real upload_file** via CDP DOM.setFileInputFiles
- **Real auth_login** iterative form fill
- **block_images** moved to instance level
- **Selector scoping** wired to JS TreeWalker
- **Auto-detect login/CAPTCHA/MFA** on navigate
- **macOS system notification** via osascript
- **Full-screen viewport** via Emulation.setDeviceMetricsOverride
- **Verification code detection** (SMS/email/2FA)

## Test plan
- [x] Tested on featherless.ai, github.com, news.ycombinator.com, local Gitea
- [x] Ref stability verified with diff snapshots
- [x] Selector scoping verified (nav selector)
- [x] Intervention banner tested on Gitea login
- [x] Viewport fills full screen (1728x1037 confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)